### PR TITLE
RTF input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6] - 2025-06-12
+### Added
+- RTF input file support
+- RTF to HTML conversion for processing
+- Support for RTF formatting (bold, italic, underline)
+
 ## [0.5] - 2025-06-11
 ### Added
 - Error messages (for wrong file format and missing headers levels)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ All notable changes to this project will be documented in this file.
 ## [0.6] - 2025-06-12
 ### Added
 - RTF input file support
-- RTF to HTML conversion for processing
-- Support for RTF formatting (bold, italic, underline)
-
-## [0.5] - 2025-06-11
-### Added
 - Error messages (for wrong file format and missing headers levels)
 
 ## [0.4] - 2025-05-29

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# DOCX Splitter v 0.5
+# DOCX Splitter v 0.6
 
-A web application that splits Microsoft Word `.docx` files by selected heading level and saves them as separate `.rtf` files.
+A web application that splits Microsoft Word `.docx` files and RTF files by selected heading level and saves them as separate `.rtf` files.
 
 ![Pepe Agent](pepeagent.gif)
 
 ## Features
 
-- Split `.docx` files by headings (H1-H6)
+- Split `.docx` and `.rtf` files by headings (H1-H6)
 - Select which heading level to split at (splits at selected level and all levels above it)
 - Clean and modern web interface
 - Automatic file naming based on headings

--- a/app.js
+++ b/app.js
@@ -124,7 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					const decoder = new TextDecoder(`windows-${codepage}`);
 					const rtfContent = decoder.decode(arrayBuffer);
 					
-					console.log('=== RTF Processing Debug ===');
+					if (debug) console.log('=== RTF Processing Debug ===');
 					
 					// Skip the RTF header and font table to get to the actual content
 					const contentStart = rtfContent.indexOf('\\viewkind');

--- a/app.js
+++ b/app.js
@@ -156,6 +156,7 @@ document.addEventListener('DOMContentLoaded', () => {
 						let text = paragraph
 							.replace(/\\[a-z0-9]+\s?/g, '')
 							.replace(/{|}/g, '')
+							.replace(/^arsid\s*/i, '')  // Remove arsid heading if present
 							.trim();
 						
 						// Convert hex escape sequences to their proper characters

--- a/app.js
+++ b/app.js
@@ -8,19 +8,26 @@ document.addEventListener('DOMContentLoaded', () => {
 	splitButton.addEventListener('click', async () => {
 		const file = docxFile.files[0];
 		if (!file) {
-			setStatus('Please select a DOCX file first', 'error');
+			setStatus('Please select a file first', 'error');
 			return;
 		}
 
-		// Check if the file is a DOCX file
-		if (!file.name.toLowerCase().endsWith('.docx')) {
-			setStatus('Unsupported file format', 'error');
+		// Check if the file is a supported format
+		const fileExtension = file.name.toLowerCase().split('.').pop();
+		if (!['docx', 'rtf'].includes(fileExtension)) {
+			setStatus('Unsupported file format. Please use DOCX or RTF files.', 'error');
 			return;
 		}
 
 		try {
 			setStatus('Processing document...', 'info');
-			const content = await processDocx(file);
+			let content;
+			
+			if (fileExtension === 'docx') {
+				content = await processDocx(file);
+			} else {
+				content = await processRtf(file);
+			}
 			
 			// Check if there are headers of the selected level
 			if (!hasHeadersOfLevel(content, parseInt(headingLevel.value))) {
@@ -89,6 +96,94 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
+	async function processRtf(file) {
+		const reader = new FileReader();
+		return new Promise((resolve, reject) => {
+			reader.onload = async (event) => {
+				try {
+					const rtfContent = event.target.result;
+					console.log('=== RTF Processing Debug ===');
+					
+					// Skip the RTF header and font table to get to the actual content
+					const contentStart = rtfContent.indexOf('\\viewkind');
+					if (contentStart === -1) {
+						throw new Error('Could not find document content in RTF file');
+					}
+					
+					const documentContent = rtfContent.substring(contentStart);
+					console.log('Document content (first 2000 chars):', documentContent.substring(0, 2000));
+					
+					// First, let's find all paragraphs
+					const paragraphs = documentContent.split('\\par');
+					console.log('Found paragraphs:', paragraphs.length);
+					
+					let processedContent = '';
+					let headerCount = 0;
+					
+					// Process each paragraph
+					paragraphs.forEach(paragraph => {
+						// Skip empty paragraphs
+						if (!paragraph.trim()) return;
+						
+						// Check if this paragraph has header-like formatting
+						const hasBold = paragraph.includes('\\b');
+						const hasFontSize = paragraph.match(/\\fs(\d+)/);
+						const fontSize = hasFontSize ? parseInt(hasFontSize[1]) : 0;
+						
+						// Extract the actual text
+						const text = paragraph
+							.replace(/\\[a-z0-9]+\s?/g, '')
+							.replace(/{|}/g, '')
+							.trim();
+						
+						if (!text) return;
+						
+						console.log('Processing paragraph:', {
+							text: text.substring(0, 50),
+							hasBold,
+							fontSize,
+							original: paragraph.substring(0, 100)
+						});
+						
+						// Determine if this is a header based on formatting
+						if (hasBold || fontSize >= 20) {
+							// Determine heading level based on font size
+							let level = 1;
+							if (fontSize >= 40) level = 1;
+							else if (fontSize >= 32) level = 2;
+							else if (fontSize >= 28) level = 3;
+							else if (fontSize >= 24) level = 4;
+							else if (fontSize >= 20) level = 5;
+							else level = 6;
+							
+							console.log('Found header:', {
+								text,
+								level,
+								fontSize
+							});
+							
+							processedContent += `<h${level}>${text}</h${level}>\n`;
+							headerCount++;
+						} else {
+							processedContent += `<p>${text}</p>\n`;
+						}
+					});
+					
+					console.log('Total headers found:', headerCount);
+					console.log('Final HTML content:', processedContent);
+					console.log('=== End RTF Processing Debug ===');
+					
+					resolve(processedContent);
+				} catch (error) {
+					console.error('Error processing RTF:', error);
+					reject(error);
+				}
+			};
+			reader.onerror = (error) => reject(error);
+			reader.readAsText(file);
+		});
+	}
+
 	// Global variable to store the codepage
 	let globalCodepage = "65001"; // Default to UTF-8
 
@@ -138,17 +233,31 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	function hasHeadersOfLevel(html, targetLevel) {
+		console.log('=== Header Level Check Debug ===');
+		console.log('Target level:', targetLevel);
+		console.log('HTML content:', html);
+		
 		const parser = new DOMParser();
 		const doc = parser.parseFromString(html, 'text/html');
 		const elements = Array.from(doc.body.childNodes);
 		
-		return elements.some(element => {
+		console.log('Document elements:', elements.map(el => ({
+			tagName: el.tagName,
+			textContent: el.textContent?.substring(0, 50)
+		})));
+		
+		const hasHeaders = elements.some(element => {
 			if (element.nodeType === Node.ELEMENT_NODE) {
 				const headingLevel = getHeadingLevel(element);
+				console.log('Element:', element.tagName, 'Level:', headingLevel, 'Text:', element.textContent?.substring(0, 50));
 				return headingLevel && headingLevel <= targetLevel;
 			}
 			return false;
 		});
+		
+		console.log('Has headers:', hasHeaders);
+		console.log('=== End Header Level Check Debug ===');
+		return hasHeaders;
 	}
 
 	async function saveSectionsAsDocx(sections) {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 			<h1>DOCX Splitter</h1>
 			<h3>Input docx and split every header into a new rtf file</h3>
 			<div class="upload-section">
-				<input type="file" id="docxFile" accept=".docx" />
+				<input type="file" id="docxFile" accept=".docx,.rtf" />
 				<select id="headingLevel" class="heading-select" title="Split at this level and all levels above it">
 					<option value="1" selected>Split at H1 only</option>
 					<option value="2">Split at H1 and H2</option>
@@ -30,6 +30,7 @@
 		</div>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.5.0/mammoth.browser.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/rtf-parser@1.0.0/dist/rtf-parser.min.js"></script>
 		<script src="app.js"></script>
 	</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"file-saver": "^2.0.5",
-				"mammoth": "^1.5.0"
+				"mammoth": "^1.5.0",
+				"rtf-parser": "^1.0.0"
 			},
 			"devDependencies": {
 				"http-server": "^14.1.1"
@@ -687,6 +688,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/rtf-parser": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rtf-parser/-/rtf-parser-1.3.3.tgz",
+			"integrity": "sha512-sz2eb4tcCFtwVfs5Ei/l3JnSQGqpDv+drFuNz/zwn2tA24cL2WTuk2VMo2bA4IcRgkn38juAOri2hB9nv85u2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"iconv-lite": "^0.4.15",
+				"readable-stream": "^2.2.2"
+			}
+		},
+		"node_modules/rtf-parser/node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -697,7 +720,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/secure-compare": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 	},
 	"dependencies": {
 		"mammoth": "^1.5.0",
-		"file-saver": "^2.0.5"
+		"file-saver": "^2.0.5",
+		"rtf-parser": "^1.0.0"
 	},
 	"devDependencies": {
 		"http-server": "^14.1.1"

--- a/user_manual.md
+++ b/user_manual.md
@@ -46,3 +46,8 @@ See [technical details](technical_details.md) for, uhm, details?
 * Why did you vibe-code it, AI is killing our market!
 
   It's killing mine, too, and the markets of plenty of my friends, but I just cannot devote several weeks to learn to code a tool I will use twice. Tried before and failed.
+
+## Error codes
+
+* `No headings of the selected size present in the document.` - the uploaded documents does not have headings of the specified level. For example, you chose H1 headings as a split point, but the document only has H2 or smaller headings.
+* `Unsupported file format.` - the file format you tried to upload is not supported.


### PR DESCRIPTION
Add support for RTF file format input.

It detects and handles stuff properly, but does not fully clean the headings - it cannot detect and remove the `{\*\bkmkstart` and `{\*\bkmkend `sequence.